### PR TITLE
Fix for  vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "cheerio": "^0.19.0",
     "es6-promise": "^3.0.2",
     "js-sha256": "^0.3.0",
-    "request": "2.61",
+    "request": "2.74.0",
     "tough-cookie": "^2.0.0"
   }
 }


### PR DESCRIPTION
skyweb currently has a vulnerable dependency, introducing [remote memory exposure](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
You can see [Snyk test report](https://snyk.io/test/github/ShyykoSerhiy/skyweb) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Community
